### PR TITLE
Reopen: [CI] Add Security Scan using `npm audit`

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -12,49 +12,76 @@ jobs:
   npm-audit:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
+      - name: Set Up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '22'
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           cd ${{ inputs.working-directory }}
           npm install
+          sudo apt-get install -y jq  #install jq for JSON parsing
 
-      - name: Run npm audit
+      - name: Run `npm audit`
         run: |
           cd ${{ inputs.working-directory }}
-          npm audit --json > audit-report.json
-          audit_output=$(npm audit)
-          
-          critical_count=$(jq '.metadata.vulnerabilities.critical' audit-report.json)
-          high_count=$(jq '.metadata.vulnerabilities.high' audit-report.json)
+          npm audit --json > audit-report.json || true
+          audit_output=$(npm audit) || true
 
-          if [ "$critical_count" -gt 0 ] && [ "$high_count" -gt 0 ]; then
-            echo "::error:: Critical vulnerabilities found: $critical_count"
-            echo "::error:: High vulnerabilities found: $high_count"
-            echo "$audit_output"
-            exit 1
-          elif [ "$critical_count" -gt 0 ]; then
-            echo "::error:: Critical vulnerabilities found: $critical_count"
-            echo "$audit_output"
-            exit 1
-          elif [ "$high_count" -gt 0 ]; then
-            echo "::error:: High vulnerabilities found: $high_count"
-            echo "$audit_output"
+          if [ -f "audit-report.json" ]; then
+            echo "Printing Working Directory:"
+            pwd
+            echo "Listing all files in printed working directory:"
+            ls -al
+
+            critical_count=$(jq '.metadata.vulnerabilities.critical' audit-report.json)
+            high_count=$(jq '.metadata.vulnerabilities.high' audit-report.json)
+            vuln_count=$(jq '.metadata.vulnerabilities.total' audit-report.json)
+
+            critical_packages=$(jq -r '.vulnerabilities | to_entries[] | select(.value.severity == "critical") | .key' audit-report.json | paste -sd "," -)
+            high_packages=$(jq -r '.vulnerabilities | to_entries[] | select(.value.severity == "high") | .key' audit-report.json | paste -sd "," -)
+            non_severe_packages=$(jq -r '.vulnerabilities | to_entries[] | select(.value.severity != "critical" and .value.severity != "high") | .key' audit-report.json | paste -sd "," -)
+
+            if [ "$critical_count" -gt 0 ] && [ "$high_count" -gt 0 ]; then
+              echo "::error:: Critical vulnerabilities found: $critical_count. Critical packages: $critical_packages."
+              echo "::error:: High vulnerabilities found: $high_count. High severity packages: $high_packages."
+              echo "$audit_output"
+              exit 1
+            elif [ "$critical_count" -gt 0 ]; then
+              echo "::error:: Critical vulnerabilities found: $critical_count. Critical packages: $critical_packages."
+              echo "$audit_output"
+              exit 1
+            elif [ "$high_count" -gt 0 ]; then
+              echo "::error:: High vulnerabilities found: $high_count. High severity packages: $high_packages."
+              echo "$audit_output"
+              exit 1
+            elif [ "$critical_count" -eq 0 ] && [ "$high_count" -eq 0 ] && [ "$vuln_count" -gt 0 ]; then
+              echo "::warning:: Non-severe vulnerabilities found: $vuln_count. Non-severe packages: $non_severe_packages."
+              echo "$audit_output"
+              exit 0
+            elif [ "$vuln_count" -eq 0 ] && [ "$high_count" -eq 0 ] && [ "$critical_count" -eq 0 ]; then
+              echo "No vulnerabilities found."
+              exit 0
+            else
+              echo "::error:: Security Scan Failed!"
+              echo "Terminating the workflow due to unknown state of security."
+              echo "$audit_output"
+              exit 1
+            fi
+          else
+            echo "::error:: audit-report.json not found. Security scan terminated."
             exit 1
           fi
 
+          echo "::notice:: Security scan complete."
 
-          vuln_count=$(jq '.metadata.vulnerabilities.total' audit-report.json)
-          if [ "$vuln_count" -gt 0 ]; then
-            echo "::warning:: Non-severe vulnerabilities found: $vuln_count"
-            echo "$audit_output"
-            exit 0
-          fi
-          
-          echo "No vulnerabilities found."
+      - name: Upload Audit Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-report
+          path: ${{ inputs.working-directory }}/audit-report.json


### PR DESCRIPTION
Previous merged PR #25 had flaws. This PR addresses that PR and issue #24.

# Security Scan for Vulnerabilities using `npm audit`

This GitHub Action performs a security scan for vulnerabilities in a Node.js project using `npm audit`. The workflow includes the following steps:

1. **Setup and Dependency Installation**:
   - Checks out the code.
   - Sets up Node.js (version 22).
   - Installs project dependencies and the `jq` tool for JSON parsing.

2. **Run `npm audit`**:
   - Executes `npm audit` and saves the output as a JSON file (`audit-report.json`).
   - Parses the audit report using `jq` to extract the count and details of vulnerabilities categorized as:
     - Critical
     - High
     - Non-severe

3. **Vulnerability Handling**:
   - Fails the workflow if critical or high vulnerabilities are found, providing details about the affected packages.
   - Issues a warning if only non-severe vulnerabilities are detected.
   - Outputs a success message if no vulnerabilities are found.

4. **Audit Report Upload**:
   - Uploads the `audit-report.json` file as an artifact for further review, regardless of the scan result.

This action ensures that critical and high-severity vulnerabilities are addressed promptly while providing visibility into non-severe issues.